### PR TITLE
fixed pyaudio IOError

### DIFF
--- a/eff_word_net/streams.py
+++ b/eff_word_net/streams.py
@@ -91,8 +91,8 @@ class SimpleMicStream(CustomAudioStream) :
             open_stream = mic_stream.start_stream,
             close_stream = mic_stream.stop_stream,
             get_next_frame = lambda : (
-                np.frombuffer(mic_stream.read(CHUNK),dtype=np.int16)
-            ),
-            window_length_secs=window_length_secs,
-            sliding_window_secs=sliding_window_secs
+                np.frombuffer(mic_stream.read(CHUNK,exception_on_overflow = False),dtype=np.int16) 
+                ),
+                 window_length_secs=window_length_secs,
+                sliding_window_secs=sliding_window_secs
         )


### PR DESCRIPTION
fixed pyaudio input overflowed error
`OSError: [Errno -9981] Input overflowed`

`exception_on_overflow = False ` does not stop the IOError, but it will allow the code to ignore it. This should allow the program to continue working, saving data to mfcc_feat, even if your model takes too long.