### PR TITLE
Fixed numpy dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.0
-PyAudio==0.2.11
+numpy==1.24.0
+onnxruntime==1.15.1
+PyAudio==0.2.13
 requests==2.26.0
-onnxruntime>=1.14.1


### PR DESCRIPTION
This pull request fixes the issue with the Numpy version. Locally it works on my machine so feel free to test and merge! I also updated the onnx dependency, however, it was not bounded anyways. If this is not wanted, I can revert this particular dependency.