### PR TITLE
#45 Update dependencies for Python 3.10+, add TensorFlow for Windows/Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EfficientWord-Net
-![Versions : 3.6 ,3.7,3.8,3.9](https://camo.githubusercontent.com/a7b5b417de938c1faf3602c7f48f26fde8761a977be85390fd6c0d191e210ba8/68747470733a2f2f696d672e736869656c64732e696f2f707970692f707976657273696f6e732f74656e736f72666c6f772e7376673f7374796c653d706c6173746963)
+![Versions : 3.8, 3.9, 3.10, 3.11, 3.12](https://camo.githubusercontent.com/a7b5b417de938c1faf3602c7f48f26fde8761a977be85390fd6c0d191e210ba8/68747470733a2f2f696d672e736869656c64732e696f2f707970692f707976657273696f6e732f74656e736f72666c6f772e7376673f7374796c653d706c6173746963)
 
 ## Hotword detection based on few-shot learning
 
@@ -25,7 +25,7 @@ Here are the links: https://drive.google.com/file/d/1f6dp72D9WxErXvaZP6KIBLv4-eK
 ## Python Version Requirements
 
 This Library works between python versions:
-    `3.6 to 3.9`
+    `3.8 to 3.12`
 <br>
 
 ## Dependencies Installation
@@ -37,6 +37,7 @@ Before running the pip installation command for the library, few dependencies ne
 Mac OS M* and Raspberry Pi users might have to compile these dependecies.
 
 ***tflite*** package cannot be listed in requirements.txt hence will be automatically installed when the package is initialized in the system.
+On Windows and Mac, use tensorflow instead.
 
 ***librosa*** package is not required for inference only cases , however when generate_reference is called , will be automatically installed.
 

--- a/eff_word_net/__init__.py
+++ b/eff_word_net/__init__.py
@@ -3,9 +3,11 @@
 """
 
 import os
+import sys
 RATE=16000
 samples_loc = os.path.join(os.path.dirname(os.path.realpath(__file__)),"sample_refs")
 
 from eff_word_net.package_installation_scripts import check_install_tflite
 
-check_install_tflite()
+if sys.platform=="linux":
+    check_install_tflite()

--- a/eff_word_net/audio_processing.py
+++ b/eff_word_net/audio_processing.py
@@ -1,5 +1,8 @@
-import glob
-import tflite_runtime.interpreter as tflite
+import sys
+if sys.platform=="linux":
+    import tflite_runtime.interpreter as tflite
+else:
+    from tensorflow import lite as tflite
 import os
 import numpy as np
 import random

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy==1.24.0
-onnxruntime==1.15.1
-PyAudio==0.2.13
-requests==2.26.0
+numpy>=1.22.0
+onnxruntime>=1.14.1
+PyAudio>=0.2.13
+requests>=2.26.0
+tensorflow>=2.13.0; sys_platform != 'linux'

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,28 @@
-from setuptools import setup
-from glob import glob
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+with open("requirements.txt", "r", encoding="utf-8") as fr:
+    requirements = fr.read().splitlines()
 
 setup(
-    name = 'EfficientWord-Net',
-    version = '1.0.2',
-    description = 'Few Shot Learning based Hotword Detection Engine',
-    long_description = open("./README.md",'r').read(),
-    long_description_content_type = 'text/markdown',
-    url = 'https://github.com/Ant-Brain/EfficientWord',
-    #py_modules = ['efficientword'],
-    packages = ['eff_word_net'],
-    install_requires = open("./requirements.txt",'r').read().split("\n"),
-    classifiers = [
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+    name='EfficientWord-Net',
+    version='1.1.0',
+    description='Few Shot Learning based Hotword Detection Engine',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/Ant-Brain/EfficientWord',
+    packages=find_packages(),
+    install_requires=requirements,
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
+    python_requires='>=3.8',
     include_package_data=True,
 )
-


### PR DESCRIPTION
#45 Update dependencies for Python 3.10+, add TensorFlow for Windows/Mac

- Updated dependencies to support Python 3.10 and later versions, addressing the requirements of #45.
- Dropped support for Python 3.6 and 3.7 due to the constraints of the updated dependencies.
- Added TensorFlow for Windows and Mac to ensure compatibility. Linux will continue to use tensorflow-lite.  
As confirmed in the TensorFlow forum (https://discuss.tensorflow.org/t/how-to-install-tflite-runtime-in-windows-machine/11427), tensorflow-lite runtime is not available for platforms other than Linux.